### PR TITLE
Corrected no longer valid `ease` URL to solve compile error.

### DIFF
--- a/tools/target-platform/com.collins.trustedsystems.fmw.target.target
+++ b/tools/target-platform/com.collins.trustedsystems.fmw.target.target
@@ -21,7 +21,7 @@
       <unit id="org.eclipse.ease.modules.feature.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.ease.modules.modeling.feature.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.ease.ui.feature.feature.group" version="0.0.0"/>
-      <repository location="http://download.eclipse.org/ease/update/release"/>
+      <repository location="http://download.eclipse.org/ease/release/latest"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
       <unit id="org.py4j.feature.feature.group" version="0.0.0"/>


### PR DESCRIPTION
This pull request solves a compile error in the current master branch due to `ease` now having a different path in the eclipse repositories. I've initially set this to `latest` and it appears to work with the fmw compile, but this may not be the intention of the maintainers.